### PR TITLE
bearer: inject `Token` instead of `User`

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -9,9 +9,6 @@ import (
 	"crypto/subtle"
 )
 
-// User is the authenticated username that was extracted from the request.
-type User string
-
 // SecureCompare performs a constant time compare of two strings to prevent
 // timing attacks.
 func SecureCompare(given, actual string) bool {

--- a/basic.go
+++ b/basic.go
@@ -14,6 +14,9 @@ import (
 
 const basicPrefix = "Basic "
 
+// User is the authenticated username that was extracted from the request.
+type User string
+
 // Basic returns a middleware handler that injects auth.User into the request
 // context upon successful basic authentication. The handler responds
 // http.StatusUnauthorized when authentication fails.

--- a/basic_test.go
+++ b/basic_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/flamego/flamego"
 )
@@ -23,35 +24,41 @@ func TestBasic(t *testing.T) {
 		username string
 		password string
 		wantCode int
+		wantBody string
 	}{
 		{
 			name:     "good",
 			username: "foo",
 			password: "bar",
 			wantCode: http.StatusOK,
+			wantBody: "foo",
 		},
 		{
 			name:     "bad",
 			username: "bar",
 			password: "foo",
 			wantCode: http.StatusUnauthorized,
+			wantBody: "Unauthorized\n",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			f := flamego.NewWithLogger(&bytes.Buffer{})
 			f.Use(Basic("foo", "bar"))
-			f.Get("/", func() {})
+			f.Get("/", func(user User) string {
+				return string(user)
+			})
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodGet, "/", nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			auth := strings.Join([]string{test.username, test.password}, ":")
 			req.Header.Set("Authorization", basicPrefix+base64.StdEncoding.EncodeToString([]byte(auth)))
 			f.ServeHTTP(resp, req)
 
 			assert.Equal(t, test.wantCode, resp.Code)
+			assert.Equal(t, test.wantBody, resp.Body.String())
 		})
 	}
 }
@@ -61,31 +68,37 @@ func TestBasicFunc(t *testing.T) {
 		name     string
 		header   string
 		wantCode int
+		wantBody string
 	}{
 		{
 			name:     "primary password",
 			header:   basicPrefix + "Zm9vOmJhcg==", // foo:bar
 			wantCode: http.StatusOK,
+			wantBody: "foo",
 		},
 		{
 			name:     "secondary password",
 			header:   basicPrefix + "Zm9vOmJheg==", // foo:baz
 			wantCode: http.StatusOK,
+			wantBody: "foo",
 		},
 		{
 			name:     "wrong password",
 			header:   basicPrefix + "Zm9vOm5vcGU=", // foo:nope
 			wantCode: http.StatusUnauthorized,
+			wantBody: "Unauthorized\n",
 		},
 		{
 			name:     "bad prefix",
 			header:   "Zm9vOmJheg==", // foo:baz
 			wantCode: http.StatusUnauthorized,
+			wantBody: "Unauthorized\n",
 		},
 		{
 			name:     "bad encoding",
 			header:   basicPrefix + "Zm9vOm5",
 			wantCode: http.StatusUnauthorized,
+			wantBody: "Unauthorized\n",
 		},
 	}
 	for _, test := range tests {
@@ -94,16 +107,19 @@ func TestBasicFunc(t *testing.T) {
 			f.Use(BasicFunc(func(username, password string) bool {
 				return username == "foo" && (password == "bar" || password == "baz")
 			}))
-			f.Get("/", func() {})
+			f.Get("/", func(user User) string {
+				return string(user)
+			})
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodGet, "/", nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			req.Header.Set("Authorization", test.header)
 			f.ServeHTTP(resp, req)
 
 			assert.Equal(t, test.wantCode, resp.Code)
+			assert.Equal(t, test.wantBody, resp.Body.String())
 		})
 	}
 }

--- a/bearer.go
+++ b/bearer.go
@@ -12,6 +12,9 @@ import (
 
 var bearerPrefix = "Bearer "
 
+// Token is the authenticated token that was extracted from the request.
+type Token string
+
 // Bearer returns a middleware handler that injects auth.User (empty string)
 // into the request context upon successful bearer authentication. The handler
 // responds http.StatusUnauthorized when authentication fails.
@@ -22,7 +25,7 @@ func Bearer(token string) flamego.Handler {
 			bearerUnauthorized(c.ResponseWriter())
 			return
 		}
-		c.Map(User(""))
+		c.Map(Token(token))
 	})
 }
 
@@ -37,11 +40,13 @@ func BearerFunc(fn func(token string) bool) flamego.Handler {
 			bearerUnauthorized(c.ResponseWriter())
 			return
 		}
-		if !fn(auth[n:]) {
+
+		token := auth[n:]
+		if !fn(token) {
 			bearerUnauthorized(c.ResponseWriter())
 			return
 		}
-		c.Map(User(""))
+		c.Map(Token(token))
 	})
 }
 


### PR DESCRIPTION
### Describe the pull request

It does not make sense to inject `User` with an empty string for token-based authentication. The token should be passed down to further identifying user upon successful authentication.

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
